### PR TITLE
Stricter type checking

### DIFF
--- a/config/ts.config.json
+++ b/config/ts.config.json
@@ -46,6 +46,8 @@
 		// JSX is preserved so that we can handle JSX with babel-preset-solid
 		// (for use with @lume/element).
 		"jsx": "preserve",
+		// Default to supporting Solid JSX by default. This is the default the Lume project uses right now.
+		"jsxImportSource": "solid-js",
 
 		"pretty": true,
 		"declaration": true,

--- a/config/ts.config.json
+++ b/config/ts.config.json
@@ -38,7 +38,8 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"forceConsistentCasingInFileNames": true,
-		// "noImplicitOverride": true, // TODO, many type errors will result (f.e. in the lume package)
+		"noImplicitOverride": true,
+		"noUncheckedIndexedAccess": true,
 
 		// Language feature options
 		"useDefineForClassFields": true,


### PR DESCRIPTION
make type checking stricter by enabling `noImplicitOverride` and `noUncheckedIndexedAccess` tsconfig options.

**BREAKING:** This may cause some type errors and code will need to be adjusted. In many cases the fixes are simple: prepend `override` to class members affected by `noImplicitOverride`, or add a non-null assertion (`!`) on expressions affected by `noUncheckedIndexedAccess` if not a better conditional check.